### PR TITLE
fix: remove first:5 in get events query

### DIFF
--- a/pages/supporters/events/[slug].tsx
+++ b/pages/supporters/events/[slug].tsx
@@ -58,7 +58,7 @@ export default function EventPage({ event, preview }) {
 
 export async function getStaticPaths() {
   const response = await fetchAPI(`query LatestEventSlugs {
-  events: allEvents(first: "5") {
+  events: allEvents() {
     slug
   }
 }


### PR DESCRIPTION
the reason is that it's needed to create all event pages in build time otherwise it's gonna create just 5 pages and creating a 404 error for the rest of the events: